### PR TITLE
Corrigido link do emulador

### DIFF
--- a/_i18n/pt/_posts/cielo-lio/2017-01-01-cielo-lio.md
+++ b/_i18n/pt/_posts/cielo-lio/2017-01-01-cielo-lio.md
@@ -1149,7 +1149,7 @@ printerManager.printImage(bitmap, alignCenter, printerListener);
 1. Leia toda a documentação sobre a Integração Local.
 2. Crie sua conta no Portal de Desenvolvedores da Cielo para obter todas as funcionalidades que o portal pode oferecer para você, desenvolvedor. É obrigatório possuir uma conta para gerar um Client-Id.
 3. Realizando o cadastro de Client ID, o desenvolvedor recebe os tokens
-4. (Client ID e Access-Token) e consegue utilizar o Cielo LIO Order Manager SDK. Realize os testes no Emulador Cielo Lio Confira o link: [Download do Emulador](https://s3-sa-east-1.amazonaws.com/cielo-lio-store/apps/lio-emulator/1.0.0/lio-emulator.apk)
+4. (Client ID e Access-Token) e consegue utilizar o Cielo LIO Order Manager SDK. Realize os testes no Emulador Cielo Lio Confira o link: [Download do Emulador](https://s3-sa-east-1.amazonaws.com/cielo-lio-store/apps/lio-emulator/1.1.0/lio-emulator.apk)
 5. Acesse a [Cielo Store](https://www.cieloliostore.com.br/login) e faça o upload do APK da sua aplicação. Ao término do upload, submeta seu aplicativo para certificação e preencha todas as informações necessárias.
 6. Ao término do upload submeta seu aplicativo, no próprio ambiente da Cielo Store, para certificação e preencha todas as informações necessárias.
 7. Assim que a certificação for concluída, o desenvolvedor receberá um e-mail e deverá acessar novamente a Cielo Store para promover o aplicativo para produção.


### PR DESCRIPTION
No site da documentação há link para download do emulador em 2 locais diferentes.
Em um dos locais a versão estava 1.1.0 e em outro estava 1.0.0.
Fiz a atualização do 2º link para a versão 1.1.0.