### PR TITLE
Update 2018-09-10-env3ds.md

### DIFF
--- a/_i18n/pt/_posts/env3ds/2018-09-10-env3ds.md
+++ b/_i18n/pt/_posts/env3ds/2018-09-10-env3ds.md
@@ -248,22 +248,26 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_order_cardattemptslast24hours | Quantidade de transações com o mesmo cartão nas últimas 24h | Numérico [até 3 posições] | Não | Sim |
 | bpmpi_order_marketingoptin | Indica se o comprador aceitou receber ofertas de marketing | Booleano<br>true – sim<br>false – não  | Não | Sim |
 | bpmpi_order_marketingsource | Identifica a origem da campanha de marketing | Alfanumérico [até 40 posições] | Não | Sim |
+| bpmpi_transaction_mode | Identifica o canal que originou a transação | M: MOTO<br>R: Varejo<br>S: E-Commerce<br>P: Mobile<br>T: Tablet | Não | Sim |
+| bpmpi_merchant_url | Endereço do site do estabelcimento | Alphanumérico [100] Exemplo: http://www.exemplo.com.br | Não | Sim |
 
 | **Dados específicos para cartões Gift Card (pré-pago)** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
-| bpmpi_giftcard_amount | O total do valor da compra para cartões-presente pré-pagos em valor arredondado | Numérico [até 15 posições],<br>exemplo: R$ 125,54 = 125 | Não | Sim |
+| bpmpi_giftcard_amount | O total do valor da compra para cartões-presente pré-pagos em valor arredondado | Numérico [até 15 posições],<br>exemplo: R$ 125,54 = 12554 | Não | Sim |
 | bpmpi_giftcard_currency | Código da moeda da transação paga com cartão do tipo pré-pago | Fixo &quot;BRL&quot; | Não | Sim |
 
 | **Dados de endereço de cobrança** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
-| bpmpi_shipTo_contactName| Nome do contato do endereço de cobrança | Alfanumérico [até 120] | Não | Sim |
-| bpmpi_billTo_phoneNumber | Telefone de contato do endereço de cobrança | Alfanumérico [até 15 posições], no formato: 5511999999999 | Não | Sim |
+| bpmpi_billto_customerid | Identifica o CPF/CNPJ do comprador | Numérico [11 a 14 posições]<br>99999999999999 | Não | Sim |
+| bpmpi_billTo_contactName| Nome do contato do endereço de cobrança | Alfanumérico [até 120] | Não | Sim |
+| bpmpi_billTo_phoneNumber | Telefone de contato do endereço de cobrança | Numérico [até 15 posições], no formato: 5511999999999 | Não | Sim |
 | bpmpi_billTo_email | E-mail do contato do endereço de cobrança | Alfanumérico [até 255], no formato [nome@exemplo.com](mailto:nome@exemplo.com) | Não | Sim |
 | bpmpi_billTo_street1 | Logradouro e Número do endereço de cobrança | Alfanumérico [até 60] | Não | Sim |
 | bpmpi_billTo_street2 | Complemento e bairro do endereço de cobrança | Alfanumérico [até 60] | Não | Sim |
 | bpmpi_billTo_city | Cidade do endereço de cobrança | Alfanumérico [até 50] | Não | Sim |
 | bpmpi_billTo_state | Sigla do estado do endereço de cobrança | Texto [2 posições] | Não | Sim |
-| bpmpi_billto_zipcode | CEP do endereço de cobrança | Alfanumérico [até 10 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_billto_zipcode | CEP do endereço de cobrança | Alfanumérico [até 8 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_billto_country | País do endereço de cobrança | Texto [2 posições] Ex. BR | Não | Sim |
 
 | **Dados de endereço de entrega** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
@@ -276,6 +280,7 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_shipTo_city | Cidade do endereço de entrega | Alfanumérico [até 50] | Não | Sim |
 | bpmpi_shipTo_state | Sigla do estado do endereço de entrega | Texto [2 posições] | Não | Sim |
 | bpmpi_shipto_zipcode | CEP do endereço de entrega | Alfanumérico [8 posições], no formato: 99999999 | Não | Sim |
+| bpmpi_shipto_country | País do endereço de cobrança | Texto [2 posições] Ex. BR | Não | Sim |
 | bpmpi_shipTo_shippingMethod | Tipo do método de envio | lowcost: envio econômico<br>sameday: envio no mesmo dia<br>oneday: envio no dia seguinte<br>twoday: envio em dois dias<br>threeday: envio em três dias<br>pickup: retirada na loja<br>other: outrosnone: não há envio | Não | Sim |
 | bpmpi_shipto_firstusagedate | Indica a data de quando houve a primeira utilização do endereço de entrega | Texto<br>AAAA-MM-DD – data da criação  | Não | Sim |
 
@@ -296,6 +301,7 @@ Uma vez que a classe é mapeada em determinado campo, o script é capaz de recup
 | bpmpi_useraccount_authenticationmethod | Método de autenticação do comprador na loja | 01- Não houve autenticação<br>02- Login da própria loja<br>03- Login com ID federado<br>04- Login com autenticador FIDO | Não | Sim |
 | bpmpi_useraccount_authenticationprotocol | Dado que representa o protocolo de login efetuado na loja | Alfanumérico [até 2048 posições] | Não | Sim |
 | bpmpi_useraccount_authenticationtimestamp | A data e hora que o login foi efetuado na loja | Numérico [19 posições]<br>_YYYY-MM-ddTHH:mm:ss_ | Não | Sim |
+| bpmpi_merchant_newcustomer | Identifica se um comprador novo na loja| Booleano<br>true – sim<br>false – não  | Não | Sim |
 
 | **Dados do dispositivo utilizado para compra** | **Descrição** | **Tipo/Tamanho** | **Obrigatório para autenticação com desafio** | **Obrigatório para autenticação silenciosa (sem desafio)** |
 | --- | --- | --- | --- | --- |
@@ -366,7 +372,7 @@ Veja exemplo abaixo, descrito o envio dos dados de autenticação da requisiçã
        "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
        "Eci":"5",
        "Version":"2",
-       "RefereceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+       "ReferenceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
      }
    }
 }
@@ -405,7 +411,7 @@ curl
        "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
        "Eci":"5",
        "Version":"2",
-       "RefereceId":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+       "ReferenceId":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
      }
    }
 }
@@ -453,15 +459,19 @@ Veja exemplo abaixo, descrito o envio dos dados de autenticação da requisiçã
       <cavv>A901234A5678A0123A567A90120=</cavv>
       <xid>A90123A45678A0123A567A90123</xid>
       <eci>3</eci>
+      <versao>1</versao>
+      <dstid>3</dstid>	  
    </dados-autenticacao-mpi-externa>
 </requisicao-transacao>
 ```
 
 | **Campo** | **Descrição** | **Tipo/Tamanho** | **Obrigatório** |
 | --- | --- | --- | --- |
-| Cavv | Booleano que indica se a transação é submetida o não para o processo de autenticação| Alfanumérico [28 posições] | Sim, quando a autenticação foi um sucesso |
-| Xid | XID retornado no processo de autenticação | Alfanumérico [28 posições] | Sim, quando a versão do 3DS for &quot;1&quot; |
-| Eci | E-Commerce Indicator retornado no processo de autenticação | Numérico [até 3 posições] | Sim |
+| cavv | Booleano que indica se a transação é submetida o não para o processo de autenticação| Alfanumérico [28 posições] | Sim, quando a autenticação foi um sucesso |
+| xid | XID retornado no processo de autenticação | Alfanumérico [28 posições] | Sim, quando a versão do 3DS for &quot;1&quot; |
+| eci | E-Commerce Indicator retornado no processo de autenticação | Numérico [até 3 posições] | Sim |
+| versao | Versão do 3DS utilizado no processo de autenticação | Alfanumérico [1 posição] | Sim, quando a versão do 3DS for &quot;2&quot; |
+| dstid | RequestID retornado no processo de autenticação | GUID [36 posições] | Sim, quando a versão do 3DS for &quot;2&quot; |
 
 ### Response
 


### PR DESCRIPTION
INCLUSÕES

•	"bpmpi_transaction_mode" (depois do bpmpi_order_marketingsource), - Identifica o canal que originou a transação.  Identifies the channel from which the transaction originates. M: MOTO<br>R: Varejo<br>S: E-Commerce<br>P: Mobile<br>T: Tablet 
•	"bpmpi_merchant_url" (depois do bpmpi_transaction_mode), - Endereço do site do estabelcimento.  Alphanumérico [100] Exemplo: http://www.exemplo.com.br | Address of your company’s web site, for example, http://www.example.com.
•	"bpmpi_merchant_newcustomer", - Identifica se um comprador novo na loja. Sim=true Não=false Indicates whether the consumer is a new or existing customer with the merchant
•	"bpmpi_billto_customerid", - Identifica o CPF/CNPJ do comprador. Identifies the CPF/CNPJ of customer.
•	"bpmpi_billto_country", -  País do endereço de cobrança. Ex. BR. Billing country for the account. 
•	"bpmpi_shipto_country" - País do endereço de entrega. Ex. BR. Shippíng country for the account. 

ALTERAÇÕES

•	"bpmpi_billto_name" para "bpmpi_billto_contactname"
•	bpmpi_useraccount_authenticationtimestamp - Numérico [12 posições] AAAAMMDDHHMM para Texto [19 posições] YYYY-MM-ddTHH:mm:SS
•	bpmpi_shipTo_name para bpmpi_shipto_addressee
•	bpmpi_cardexpirationyear Numérico [2 posições] para Numérico [4 posições]
•	bpmpi_billto_zipcode Alfanumérico [até 8 posições]
•	bpmpi_shipto_zipcode Alfanumérico [até 8 posições]
•	bpmpi_billTo_phoneNumber Alfanumérico para Numérico
•	bpmpi_shipTo_phoneNumber Alfanumérico para Numérico
•	bpmpi_airline_passenger_#_ticketprice exemplo: "R$ 125,54 = 125" para exemplo: "R$ 125,54 = 12554"
•	pmpi_giftcard_amount "R$ 125,54 = 125" para exemplo: "R$ 125,54 = 12554" bpmpi_giftcard_amount 
•	bpmpi_airline_passenger_#_name "Primeiro nome do passageiro" para "Nome do passageiro"
•	No código JSON refereceId para referenceId