### PR TITLE
Update 2018-09-10-env3ds.md

### DIFF
--- a/_i18n/en/_posts/env3ds/2018-09-10-env3ds.md
+++ b/_i18n/en/_posts/env3ds/2018-09-10-env3ds.md
@@ -211,6 +211,8 @@ Once the class is mapped to it's given field, the script is able to retrieve the
 | bpmpi_order_cardattemptslast24hours | Number of orders placed with the same card in the last 24 hours | Numeric | Max 3 | No | Yes |
 | bpmpi_order_marketingoptin | Indicates whether the buyer accepted to receive marketing offers | Boolean| <br>true<br>false  | No | Yes |
 | bpmpi_order_marketingsource | Identifica a origem da campanha de marketing | Alphanumeric |Max 40 | No | Yes |
+| bpmpi_transaction_mode | Identifies the channel from which the transaction originates | M: MOTO<br>R: Varejo<br>S: E-Commerce<br>P: Mobile<br>T: Tablet | No | Yes |
+| bpmpi_merchant_url | Address of your company’s web site | Alphanumeric [100] Ex: http://www.exemplo.com.br  | No | Yes |
 
 | **Gift Card (prepaid) Specific Data** | **Description** | **Type** | **Size** | **Mandatory to challenge authentication** | **Mandatory to silent authentication (without challenge)** |
 | --- | --- | --- | --- | --- | --- |
@@ -219,14 +221,16 @@ Once the class is mapped to it's given field, the script is able to retrieve the
 
 | **Billing Address Data** | **Description** | **Type** | **Size** | **Mandatory to challenge authentication** | **Mandatory to silent authentication (without challenge)** |
 | --- | --- | --- | --- | --- |  ---|
-| bpmpi_shipTo_contactName | Billing address contact name | Alphanumeric | Max 120 | No | Yes |
-| bpmpi_billTo_phoneNumber | Billing address phone number | Alphanumeric |Max 15<br>_Format: 5511999999999_ | No | Yes |
+| bpmpi_billto_customerid | Identifies the CPF/CNPJ of customer| Numeric [11 to 14]<br>99999999999999 | No | Yes |
+| bpmpi_billTo_contactName | Billing address contact name | Alphanumeric | Max 120 | No | Yes |
+| bpmpi_billTo_phoneNumber | Billing address phone number | Numeric |Max 15<br>_Format: 5511999999999_ | No | Yes |
 | bpmpi_billTo_email | Billing address contact email | Alphanumeric |Max 255<br>_Format: [nome@exemplo.com](mailto:nome@exemplo.com)_ | No | Yes |
 | bpmpi_billTo_street1 | Street Address and Billing Address Number | Alphanumeric |Max 60 | No | Yes |
 | bpmpi_billTo_street2 | Neighborhood and complement billing address | Alphanumeric |Max 60 | No | Yes |
 | bpmpi_billTo_city | Billing address city | Alphanumeric |Max 50 | No | Yes |
 | bpmpi_billTo_state | Accuracy of billing address state | String | 2 | No | Yes |
-| bpmpi_billto_zipcode | Billing address zip code | Alphanumeric | Max 10<br>_Format: 99999999_ | No | Yes |
+| bpmpi_billto_zipcode | Billing address zip code | Alphanumeric | Max 8<br>_Format: 99999999_ | No | Yes |
+| bpmpi_billto_country | Billing country for the account | String [2] Ex. BR | No | Yes |
 
 | **Delivery Address Data** | **Description** | **Type** | **Size** | **Mandatory to challenge authentication** | **Mandatory to silent authentication (without challenge)** |
 | --- | --- | --- | --- | --- | ---|
@@ -239,6 +243,7 @@ Once the class is mapped to it's given field, the script is able to retrieve the
 | bpmpi_shipTo_city | Delivery address city | Alphanumeric | Max 50 | No | Yes |
 | bpmpi_shipTo_state | Accuracy of delivery address state | String | 2 | No | Yes |
 | bpmpi_shipto_zipcode | Delivery address zip code | Numeric | 8<br>_Format: 99999999_ | No | Yes |
+| bpmpi_shipto_country | Shipping country for the account | String [2] Ex. BR | No | Yes |
 | bpmpi_shipTo_shippingMethod | Shipping Method Type | String | lowcost<br>sameday<br>oneday<br>twoday<br>threeday<br>pickup<br>other | No | Yes |
 | bpmpi_shipto_firstusagedate | Indicates the date of first use of the delivery address | String | <br>_AAAA-MM-DD<br>Creation Date_ | No | Yes |
 
@@ -259,6 +264,7 @@ Once the class is mapped to it's given field, the script is able to retrieve the
 | bpmpi_useraccount_authenticationmethod | Customer's Authentication Method | String | 01 - _No authentication_<br>02 - _Store login_<br>03 - _Login with federated ID_<br>04 - _Login with FIDO authenticator_ | No | Yes |
 | bpmpi_useraccount_authenticationprotocol | In-store login protocol | Alphanumeric | Max 2048 | No | Yes |
 | bpmpi_useraccount_authenticationtimestamp | Date and time the store was logged in | String | 19<br>_YYYY-MM-ddTHH:mm:ss_ | No | Yes |
+| bpmpi_merchant_newcustomer | Indicates whether the consumer is a new or existing customer with the merchant | Boolean<br>true – yes<br>false – no  | No | Yes |
 
 | **Device Data (from purchase)** | **Description** | **Type** | **Size** | **Mandatory to challenge authentication** | **Mandatory to silent authentication (without challenge)** |
 | --- | --- | --- | --- | --- | ---| 
@@ -329,7 +335,7 @@ You can find below an example of the authorization request including authenticat
        "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
        "Eci":"5",
        "Version":"2",
-       "RefereceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+       "ReferenceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
      }
    }
 }
@@ -368,7 +374,7 @@ curl
        "Xid":"Uk5ZanBHcWw2RjRCbEN5dGtiMTB=",
        "Eci":"5",
        "Version":"2",
-       "RefereceId":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
+       "ReferenceID":"a24a5d87-b1a1-4aef-a37b-2f30b91274e6"
      }
    }
 }
@@ -416,15 +422,19 @@ You can find below an example of the authorization request including authenticat
       <cavv>A901234A5678A0123A567A90120=</cavv>
       <xid>A90123A45678A0123A567A90123</xid>
       <eci>3</eci>
+      <versao>1</versao>
+      <dstid>3</dstid>	  
    </dados-autenticacao-mpi-externa>
 </requisicao-transacao>
 ```
 
 | **Parameter** | **Description** | **Type** | **Size** | **Mandatory** |
 | --- | --- | --- | --- | --- |
-| Cavv | Boolean that indicates if the transaction is submitted to authentication process | Alphanumeric | 28 | Yes (_when authentication is successfull_) |
-| Xid | XID returned in the authentication process | Alphanumeric | 28 | Yes (_when 3DS version is  &quot;1&quot;_) |
-| Eci | E-Commerce Indicator returned in authentication process | Numeric | Max 3 | Yes |
+| cavv | Boolean that indicates if the transaction is submitted to authentication process | Alphanumeric | 28 | Yes (_when authentication is successfull_) |
+| xid | XID returned in the authentication process | Alphanumeric | 28 | Yes (_when 3DS version is  &quot;1&quot;_) |
+| eci | E-Commerce Indicator returned in authentication process | Numeric | Max 3 | Yes |
+| versao | 3DS version used in authentication process | Alphanumeric [1] | Yes, (_when 3DS version is  &quot;2&quot;_) |
+| dstid | RequestID returned in authentication process | GUID [36] | Yes (_when 3DS version is  &quot;2&quot;_) |
 
 ### Response
 


### PR DESCRIPTION
INCLUSÕES

•	"bpmpi_transaction_mode" (depois do bpmpi_order_marketingsource), - Identifica o canal que originou a transação.  Identifies the channel from which the transaction originates. M: MOTO<br>R: Varejo<br>S: E-Commerce<br>P: Mobile<br>T: Tablet 
•	"bpmpi_merchant_url" (depois do bpmpi_transaction_mode), - Endereço do site do estabelcimento.  Alphanumérico [100] Exemplo: http://www.exemplo.com.br | Address of your company’s web site, for example, http://www.example.com.
•	"bpmpi_merchant_newcustomer", - Identifica se um comprador novo na loja. Sim=true Não=false Indicates whether the consumer is a new or existing customer with the merchant
•	"bpmpi_billto_customerid", - Identifica o CPF/CNPJ do comprador. Identifies the CPF/CNPJ of customer.
•	"bpmpi_billto_country", -  País do endereço de cobrança. Ex. BR. Billing country for the account. 
•	"bpmpi_shipto_country" - País do endereço de entrega. Ex. BR. Shippíng country for the account. 

ALTERAÇÕES

•	"bpmpi_billto_name" para "bpmpi_billto_contactname"
•	bpmpi_useraccount_authenticationtimestamp - Numérico [12 posições] AAAAMMDDHHMM para Texto [19 posições] YYYY-MM-ddTHH:mm:SS
•	bpmpi_shipTo_name para bpmpi_shipto_addressee
•	bpmpi_cardexpirationyear Numérico [2 posições] para Numérico [4 posições]
•	bpmpi_billto_zipcode Alfanumérico [até 8 posições]
•	bpmpi_shipto_zipcode Alfanumérico [até 8 posições]
•	bpmpi_billTo_phoneNumber Alfanumérico para Numérico
•	bpmpi_shipTo_phoneNumber Alfanumérico para Numérico
•	bpmpi_airline_passenger_#_ticketprice exemplo: "R$ 125,54 = 125" para exemplo: "R$ 125,54 = 12554"
•	pmpi_giftcard_amount "R$ 125,54 = 125" para exemplo: "R$ 125,54 = 12554" bpmpi_giftcard_amount 
•	bpmpi_airline_passenger_#_name "Primeiro nome do passageiro" para "Nome do passageiro"
•	No código JSON refereceId para referenceId